### PR TITLE
fixes #1

### DIFF
--- a/include/cuda/cuda_matrix.cuh
+++ b/include/cuda/cuda_matrix.cuh
@@ -162,6 +162,7 @@ class CUDAMatrix : CUDAMatrixBase {
         // Clear the Host data
         host_data.clear();
         device_data.clear();
+        device_data_full.clear();
         // Host is not ahead
         host_is_ahead = false;
         // The matrix is no longer constructed


### PR DESCRIPTION
fixes
```
terminate called after throwing an instance of 
'thrust::THRUST_200500_520_NS::system::system_error'
   what():  CUDA free failed: cudaErrorCudartUnloading: driver shutting 
 down
```